### PR TITLE
feat: add user registration with email flow and implement token valid…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>

--- a/src/main/java/com/userauth/UserAuthApiApplication.java
+++ b/src/main/java/com/userauth/UserAuthApiApplication.java
@@ -2,12 +2,12 @@ package com.userauth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class UserAuthApiApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(UserAuthApiApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/userauth/application/dto/ActivationRequestDTO.java
+++ b/src/main/java/com/userauth/application/dto/ActivationRequestDTO.java
@@ -1,0 +1,9 @@
+package com.userauth.application.dto;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ActivationRequestDTO {
+    @NotBlank(message = "La contraseña es requerida")
+    private String password;
+}

--- a/src/main/java/com/userauth/application/dto/ActivationResponseDTO.java
+++ b/src/main/java/com/userauth/application/dto/ActivationResponseDTO.java
@@ -1,0 +1,12 @@
+package com.userauth.application.dto;
+
+import lombok.Data;
+
+@Data
+public class ActivationResponseDTO {
+    private String message;
+
+    public ActivationResponseDTO(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/userauth/application/dto/RegisterRequestDTO.java
+++ b/src/main/java/com/userauth/application/dto/RegisterRequestDTO.java
@@ -1,0 +1,16 @@
+package com.userauth.application.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class RegisterRequestDTO {
+    @NotBlank(message = "Full name is required")
+    private String fullName;
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email should be valid")
+    private String email;
+}
+

--- a/src/main/java/com/userauth/application/dto/RegisterResponseDTO.java
+++ b/src/main/java/com/userauth/application/dto/RegisterResponseDTO.java
@@ -1,0 +1,12 @@
+package com.userauth.application.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class RegisterResponseDTO {
+    private String message;
+    private String email;
+
+}

--- a/src/main/java/com/userauth/application/service/UserApplicationService.java
+++ b/src/main/java/com/userauth/application/service/UserApplicationService.java
@@ -1,0 +1,43 @@
+package com.userauth.application.service;
+
+import com.userauth.application.dto.RegisterRequestDTO;
+import com.userauth.domain.model.User;
+import com.userauth.domain.ports.EmailServicePort;
+import com.userauth.domain.ports.UserRepositoryPort;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+public class UserApplicationService {
+
+    private final UserRepositoryPort userRepository;
+    private final EmailServicePort mailSender;
+
+    public UserApplicationService(UserRepositoryPort userRepository, EmailServicePort mailSender) {
+        this.userRepository = userRepository;
+        this.mailSender = mailSender;
+    }
+
+    public void registerUser(RegisterRequestDTO dto) {
+        // Validar si el email ya existe
+        User existingUser = userRepository.findByEmail(dto.getEmail());
+        if (existingUser != null) {
+            throw new RuntimeException("El correo electrónico ya está registrado");
+        }
+        // Crear usuario
+        User user = new User();
+
+        user.setFullName(dto.getFullName());
+        user.setEmail(dto.getEmail());
+        user.setActive(false);
+        user.setActivationToken(UUID.randomUUID().toString());
+        user.setTokenExpiration(LocalDateTime.now().plusHours(2));
+        // Guardar usuario
+        userRepository.save(user);
+        // Enviar email
+        String activationLink = "http://localhost:8080/api/auth/activate/" + user.getActivationToken();
+        mailSender.sendActivationEmail(user.getEmail(), activationLink);
+    }
+}
+

--- a/src/main/java/com/userauth/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/userauth/config/PasswordEncoderConfig.java
@@ -1,0 +1,16 @@
+package com.userauth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}
+

--- a/src/main/java/com/userauth/domain/model/ActivationToken.java
+++ b/src/main/java/com/userauth/domain/model/ActivationToken.java
@@ -1,0 +1,14 @@
+package com.userauth.domain.model;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+public class ActivationToken {
+    private Long id;
+    private String token;
+    private Long userId;
+    private LocalDateTime createdAt;
+    private LocalDateTime expiresAt;
+    private boolean used;
+}

--- a/src/main/java/com/userauth/domain/model/User.java
+++ b/src/main/java/com/userauth/domain/model/User.java
@@ -1,0 +1,20 @@
+package com.userauth.domain.model;
+
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    private long id;
+    private String fullName;
+    private String email;
+    private String password;
+    private boolean active;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String activationToken;
+    private LocalDateTime tokenExpiration;
+}

--- a/src/main/java/com/userauth/domain/ports/ActivationTokenRepositoryPort.java
+++ b/src/main/java/com/userauth/domain/ports/ActivationTokenRepositoryPort.java
@@ -1,0 +1,9 @@
+package com.userauth.domain.ports;
+
+import com.userauth.domain.model.ActivationToken;
+
+public interface ActivationTokenRepositoryPort {
+    ActivationToken save(ActivationToken token);
+    ActivationToken findByToken(String token);
+    void markAsUsed(String token);
+}

--- a/src/main/java/com/userauth/domain/ports/EmailServicePort.java
+++ b/src/main/java/com/userauth/domain/ports/EmailServicePort.java
@@ -1,0 +1,7 @@
+package com.userauth.domain.ports;
+
+public interface EmailServicePort {
+    void sendActivationEmail(String email, String activationToken);
+    void sendPasswordResetEmail(String email, String resetToken);
+}
+

--- a/src/main/java/com/userauth/domain/ports/UserRepositoryPort.java
+++ b/src/main/java/com/userauth/domain/ports/UserRepositoryPort.java
@@ -1,0 +1,12 @@
+package com.userauth.domain.ports;
+
+import com.userauth.domain.model.User;
+
+import java.util.Optional;
+
+public interface UserRepositoryPort {
+    User save(User user);
+    User findByEmail(String email);
+    Optional<User> findById(Long userId);
+}
+

--- a/src/main/java/com/userauth/domain/ports/UserServicePort.java
+++ b/src/main/java/com/userauth/domain/ports/UserServicePort.java
@@ -1,0 +1,13 @@
+package com.userauth.domain.ports;
+
+import com.userauth.domain.model.User;
+
+import java.util.UUID;
+
+public interface UserServicePort {
+    User registerUser(String fullName, String email);
+    User findByEmail(String email);
+    void activateUser(String token, String password);
+    User save(User user);
+    User findById(long userId);
+}

--- a/src/main/java/com/userauth/domain/service/ActivationService.java
+++ b/src/main/java/com/userauth/domain/service/ActivationService.java
@@ -1,0 +1,76 @@
+package com.userauth.domain.service;
+
+import com.userauth.domain.model.ActivationToken;
+import com.userauth.domain.model.User;
+import com.userauth.domain.ports.ActivationTokenRepositoryPort;
+import com.userauth.domain.ports.UserServicePort;
+import com.userauth.exceptions.InvalidTokenException;
+import com.userauth.exceptions.TokenAlreadyUsedException;
+import com.userauth.exceptions.TokenExpiredException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ActivationService {
+
+    private final ActivationTokenRepositoryPort tokenRepository;
+    private final UserServicePort userService;
+    private final PasswordEncoder passwordEncoder;
+
+    public void validateToken(String token) throws TokenAlreadyUsedException, TokenExpiredException {
+        // Validación básica del token
+        if (token == null || token.isBlank()) {
+            throw new InvalidTokenException("Token no puede estar vacío");
+        }
+
+        // Buscar token en la base de datos
+        ActivationToken activationToken = tokenRepository.findByToken(token.trim());
+        System.out.println("Token buscado: " + token); // Log para depuración
+
+        if (activationToken == null) {
+            throw new InvalidTokenException("Token no encontrado en la base de datos");
+        }
+
+        if (activationToken.isUsed()) {
+            throw new TokenAlreadyUsedException("Este token ya fue utilizado");
+        }
+
+        if (activationToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new TokenExpiredException("Token expirado");
+        }
+
+        // Verificar que el usuario existe
+        User user = userService.findById(activationToken.getUserId());
+        if (user == null) {
+            throw new InvalidTokenException("Usuario asociado al token no existe");
+        }
+    }
+    public void activateUser(String token, String password) throws TokenExpiredException, TokenAlreadyUsedException {
+        // 1. Validar el token primero
+        validateToken(token);
+
+        // 2. Obtener el token completo
+        ActivationToken activationToken = tokenRepository.findByToken(token);
+        if (activationToken == null) {
+            throw new InvalidTokenException("Token no encontrado");
+        }
+
+        // 3. Obtener el usuario con mejor manejo de errores
+        try {
+            User user = userService.findById(activationToken.getUserId());
+
+            // 4. Actualizar usuario
+            user.setPassword(passwordEncoder.encode(password));
+            user.setActive(true);
+            userService.save(user);
+
+            // 5. Marcar token como usado
+            tokenRepository.markAsUsed(token);
+        } catch (RuntimeException e) {
+            throw new InvalidTokenException("Error activando usuario: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/userauth/domain/service/UserServiceImpl.java
+++ b/src/main/java/com/userauth/domain/service/UserServiceImpl.java
@@ -1,0 +1,77 @@
+package com.userauth.domain.service;
+import com.userauth.domain.model.ActivationToken;
+import com.userauth.domain.model.User;
+import com.userauth.domain.ports.ActivationTokenRepositoryPort;
+import com.userauth.domain.ports.EmailServicePort;
+import com.userauth.domain.ports.UserRepositoryPort;
+import com.userauth.domain.ports.UserServicePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserServicePort {
+
+    private final UserRepositoryPort userRepositoryPort;
+    private final PasswordEncoder passwordEncoder;
+    private final ActivationTokenRepositoryPort activationTokenRepositoryPort;
+    private final EmailServicePort emailServicePort;
+
+
+    @Override
+    public User registerUser(String fullName, String email) {
+        // 1. Crear y guardar usuario
+        User user = new User();
+        user.setFullName(fullName);
+        user.setEmail(email);
+        user.setActive(false);
+        user.setCreatedAt(LocalDateTime.now());
+        user.setUpdatedAt(LocalDateTime.now());
+        User savedUser = userRepositoryPort.save(user);
+
+        // 2. Verificar que el usuario tiene ID
+        if (savedUser.getId() == 0) {
+            throw new RuntimeException("Error al guardar usuario - ID no generado");
+        }
+
+        // 3. Crear token con el ID correcto
+        ActivationToken token = new ActivationToken();
+        token.setToken(UUID.randomUUID().toString());
+        token.setUserId(savedUser.getId()); // Asegúrate que este es el ID correcto
+        token.setCreatedAt(LocalDateTime.now());
+        token.setExpiresAt(LocalDateTime.now().plusDays(1));
+        token.setUsed(false);
+
+        activationTokenRepositoryPort.save(token);
+
+        // 4. Enviar email
+        emailServicePort.sendActivationEmail(email, token.getToken());
+
+        return savedUser;
+    }
+
+    @Override
+    public User findByEmail(String email) {
+        return userRepositoryPort.findByEmail(email);
+    }
+
+    @Override
+    public void activateUser(String token, String password) {
+        // Implementación en el siguiente paso
+    }
+
+    @Override
+    public User save(User user) {
+        return userRepositoryPort.save(user);
+    }
+
+    @Override
+    public User findById(long userId) {
+        return userRepositoryPort.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado con ID: " + userId));
+    }
+
+}

--- a/src/main/java/com/userauth/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/userauth/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.userauth.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<String> handleInvalidToken(InvalidTokenException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(TokenExpiredException.class)
+    public ResponseEntity<String> handleTokenExpired(TokenExpiredException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(TokenAlreadyUsedException.class)
+    public ResponseEntity<String> handleTokenUsed(TokenAlreadyUsedException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+}

--- a/src/main/java/com/userauth/exceptions/InvalidTokenException.java
+++ b/src/main/java/com/userauth/exceptions/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.userauth.exceptions;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/userauth/exceptions/TokenAlreadyUsedException.java
+++ b/src/main/java/com/userauth/exceptions/TokenAlreadyUsedException.java
@@ -1,0 +1,7 @@
+package com.userauth.exceptions;
+
+public class TokenAlreadyUsedException extends Throwable {
+    public TokenAlreadyUsedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/userauth/exceptions/TokenExpiredException.java
+++ b/src/main/java/com/userauth/exceptions/TokenExpiredException.java
@@ -1,0 +1,8 @@
+package com.userauth.exceptions;
+
+public class TokenExpiredException extends Throwable {
+
+    public TokenExpiredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/userauth/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/userauth/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.userauth.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                new AntPathRequestMatcher("/api/auth/**"),
+                                new AntPathRequestMatcher("/swagger-ui/**"),
+                                new AntPathRequestMatcher("/v3/api-docs/**"),
+                                new AntPathRequestMatcher("/error")
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/userauth/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/userauth/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,18 @@
+package com.userauth.infrastructure.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("User Authentication API")
+                        .version("1.0")
+                        .description("API for user authentication and management"));
+    }
+}

--- a/src/main/java/com/userauth/infrastructure/persistence/adapter/ActivationTokenRepositoryAdapter.java
+++ b/src/main/java/com/userauth/infrastructure/persistence/adapter/ActivationTokenRepositoryAdapter.java
@@ -1,0 +1,40 @@
+package com.userauth.infrastructure.persistence.adapter;
+import com.userauth.domain.model.ActivationToken;
+import com.userauth.domain.ports.ActivationTokenRepositoryPort;
+import com.userauth.infrastructure.persistence.entity.ActivationTokenEntity;
+import com.userauth.infrastructure.persistence.mapper.ActivationTokenMapper;
+import com.userauth.infrastructure.persistence.repository.JpaActivationTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ActivationTokenRepositoryAdapter implements ActivationTokenRepositoryPort {
+
+    private final JpaActivationTokenRepository jpaRepository;
+    private final ActivationTokenMapper mapper;
+
+    @Override
+    public ActivationToken save(ActivationToken token) {
+        ActivationTokenEntity entity = mapper.toEntity(token);
+        entity = jpaRepository.save(entity);
+        return mapper.toDomain(entity);
+    }
+
+    @Override
+    public ActivationToken findByToken(String token) {
+        // Modificar para mejor manejo de errores
+        if (token == null || token.isBlank()) {
+            return null;
+        }
+
+        return jpaRepository.findByToken(token.trim())
+                .map(mapper::toDomain)
+                .orElse(null);
+    }
+
+    @Override
+    public void markAsUsed(String token) {
+        jpaRepository.markAsUsed(token);
+    }
+}

--- a/src/main/java/com/userauth/infrastructure/persistence/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/userauth/infrastructure/persistence/adapter/UserRepositoryAdapter.java
@@ -1,0 +1,37 @@
+package com.userauth.infrastructure.persistence.adapter;
+
+import com.userauth.domain.model.User;
+import com.userauth.domain.ports.UserRepositoryPort;
+import com.userauth.infrastructure.persistence.entity.UserEntity;
+import com.userauth.infrastructure.persistence.mapper.UserMapper;
+import com.userauth.infrastructure.persistence.repository.JpaUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class UserRepositoryAdapter implements UserRepositoryPort {
+
+    private final JpaUserRepository jpaUserRepository;
+    private final UserMapper userMapper;
+
+    @Override
+    public User save(User user) {
+        UserEntity entity = userMapper.toEntity(user);
+        entity = jpaUserRepository.save(entity);
+        return userMapper.toDomain(entity);
+    }
+
+    @Override
+    public User findByEmail(String email) {
+        Optional<UserEntity> entity = jpaUserRepository.findByEmail(email);
+        return entity.map(userMapper::toDomain).orElse(null);
+    }
+
+    @Override
+    public Optional<User> findById(Long userId) {
+        return jpaUserRepository.findById(userId)
+                .map(userMapper::toDomain);
+    }
+}

--- a/src/main/java/com/userauth/infrastructure/persistence/entity/ActivationTokenEntity.java
+++ b/src/main/java/com/userauth/infrastructure/persistence/entity/ActivationTokenEntity.java
@@ -1,0 +1,29 @@
+package com.userauth.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "activation_tokens")
+public class ActivationTokenEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private boolean used = false;
+}

--- a/src/main/java/com/userauth/infrastructure/persistence/entity/UserEntity.java
+++ b/src/main/java/com/userauth/infrastructure/persistence/entity/UserEntity.java
@@ -1,0 +1,38 @@
+package com.userauth.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Entity
+@Table(name = "users")
+public class UserEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(nullable = false)
+    private String fullName;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    private String password;
+
+    @Column(nullable = false)
+    private boolean active = false;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/userauth/infrastructure/persistence/mapper/ActivationTokenMapper.java
+++ b/src/main/java/com/userauth/infrastructure/persistence/mapper/ActivationTokenMapper.java
@@ -1,0 +1,41 @@
+package com.userauth.infrastructure.persistence.mapper;
+
+import com.userauth.domain.model.ActivationToken;
+import com.userauth.infrastructure.persistence.entity.ActivationTokenEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ActivationTokenMapper {
+
+    public ActivationToken toDomain(ActivationTokenEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        ActivationToken domain = new ActivationToken();
+        domain.setId(entity.getId());
+        domain.setToken(entity.getToken());
+        domain.setUserId(entity.getUserId());
+        domain.setCreatedAt(entity.getCreatedAt());
+        domain.setExpiresAt(entity.getExpiresAt());
+        domain.setUsed(entity.isUsed());
+
+        return domain;
+    }
+
+    public ActivationTokenEntity toEntity(ActivationToken domain) {
+        if (domain == null) {
+            return null;
+        }
+
+        ActivationTokenEntity entity = new ActivationTokenEntity();
+        entity.setId(domain.getId());
+        entity.setToken(domain.getToken());
+        entity.setUserId(domain.getUserId());
+        entity.setCreatedAt(domain.getCreatedAt());
+        entity.setExpiresAt(domain.getExpiresAt());
+        entity.setUsed(domain.isUsed());
+
+        return entity;
+    }
+}

--- a/src/main/java/com/userauth/infrastructure/persistence/mapper/UserMapper.java
+++ b/src/main/java/com/userauth/infrastructure/persistence/mapper/UserMapper.java
@@ -1,0 +1,44 @@
+package com.userauth.infrastructure.persistence.mapper;
+
+import com.userauth.domain.model.User;
+import com.userauth.infrastructure.persistence.entity.UserEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+    public User toDomain(UserEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        User user = new User();
+        user.setId(entity.getId());
+        user.setFullName(entity.getFullName());
+        user.setEmail(entity.getEmail());
+        user.setPassword(entity.getPassword());
+        user.setActive(entity.isActive());
+        user.setCreatedAt(entity.getCreatedAt());
+        user.setUpdatedAt(entity.getUpdatedAt());
+
+        return user;
+    }
+
+    public UserEntity toEntity(User domain) {
+        if (domain == null) {
+            return null;
+        }
+
+        UserEntity entity = new UserEntity();
+        entity.setId(domain.getId());
+        entity.setFullName(domain.getFullName());
+        entity.setEmail(domain.getEmail());
+        entity.setPassword(domain.getPassword());
+        entity.setActive(domain.isActive());
+        entity.setCreatedAt(domain.getCreatedAt());
+        entity.setUpdatedAt(domain.getUpdatedAt());
+
+        return entity;
+    }
+}
+

--- a/src/main/java/com/userauth/infrastructure/persistence/repository/JpaActivationTokenRepository.java
+++ b/src/main/java/com/userauth/infrastructure/persistence/repository/JpaActivationTokenRepository.java
@@ -1,0 +1,17 @@
+package com.userauth.infrastructure.persistence.repository;
+
+import com.userauth.infrastructure.persistence.entity.ActivationTokenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Optional;
+
+public interface JpaActivationTokenRepository extends JpaRepository<ActivationTokenEntity, Long> {
+    Optional<ActivationTokenEntity> findByToken(String token);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE ActivationTokenEntity t SET t.used = true WHERE t.token = ?1")
+    void markAsUsed(String token);
+}

--- a/src/main/java/com/userauth/infrastructure/persistence/repository/JpaUserRepository.java
+++ b/src/main/java/com/userauth/infrastructure/persistence/repository/JpaUserRepository.java
@@ -1,0 +1,9 @@
+package com.userauth.infrastructure.persistence.repository;
+
+import com.userauth.infrastructure.persistence.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface JpaUserRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findByEmail(String email);
+}

--- a/src/main/java/com/userauth/infrastructure/services/EmailServiceImpl.java
+++ b/src/main/java/com/userauth/infrastructure/services/EmailServiceImpl.java
@@ -1,0 +1,36 @@
+package com.userauth.infrastructure.services;
+
+import com.userauth.domain.ports.EmailServicePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailServicePort {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${app.base-url}")
+    private String baseUrl;
+
+    @Override
+    public void sendActivationEmail(String email, String activationToken) {
+        String activationLink = baseUrl + "/api/auth/activate?token=" + activationToken;
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("Activate your account");
+        message.setText("Please click the following link to activate your account and set your password:\n"
+                + activationLink);
+
+        mailSender.send(message);
+    }
+
+    @Override
+    public void sendPasswordResetEmail(String email, String resetToken) {
+        // Implementación en el paso de recuperación de contraseña
+    }
+}

--- a/src/main/java/com/userauth/infrastructure/web/ActivationController.java
+++ b/src/main/java/com/userauth/infrastructure/web/ActivationController.java
@@ -1,0 +1,61 @@
+package com.userauth.infrastructure.web;
+
+import com.userauth.application.dto.ActivationRequestDTO;
+import com.userauth.application.dto.ActivationResponseDTO;
+import com.userauth.domain.service.ActivationService;
+import com.userauth.exceptions.InvalidTokenException;
+import com.userauth.exceptions.TokenAlreadyUsedException;
+import com.userauth.exceptions.TokenExpiredException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Tag(name = "Activation", description = "User Activation API")
+public class ActivationController {
+
+    private final ActivationService activationService;
+
+    @GetMapping("/activate")
+    public ResponseEntity<ActivationResponseDTO> validateToken(@RequestParam String token) {
+        try {
+            // Decodificar token por si tiene caracteres especiales
+            String decodedToken = URLDecoder.decode(token, StandardCharsets.UTF_8.name());
+            System.out.println("Token recibido: " + decodedToken); // Log de depuración
+
+            try {
+                activationService.validateToken(decodedToken);
+            } catch (TokenAlreadyUsedException e) {
+                throw new RuntimeException(e);
+            } catch (TokenExpiredException e) {
+                throw new RuntimeException(e);
+            }
+            return ResponseEntity.ok(new ActivationResponseDTO("Token válido. Por favor establece tu contraseña."));
+        } catch (Exception e) {
+            throw new InvalidTokenException("Error procesando el token: " + e.getMessage());
+        }
+    }
+
+    @PostMapping("/activate")
+    @Operation(summary = "Activate user account with password")
+    public ResponseEntity<ActivationResponseDTO> activateAccount(
+            @RequestParam String token,
+            @RequestBody ActivationRequestDTO request) {
+
+        try {
+            activationService.activateUser(token, request.getPassword());
+        } catch (TokenExpiredException e) {
+            throw new RuntimeException(e);
+        } catch (TokenAlreadyUsedException e) {
+            throw new RuntimeException(e);
+        }
+        return ResponseEntity.ok(new ActivationResponseDTO("Cuenta activada exitosamente. Ya puedes iniciar sesión."));
+    }
+}

--- a/src/main/java/com/userauth/infrastructure/web/AuthController.java
+++ b/src/main/java/com/userauth/infrastructure/web/AuthController.java
@@ -1,0 +1,53 @@
+package com.userauth.infrastructure.web;
+
+import com.userauth.application.dto.RegisterRequestDTO;
+import com.userauth.application.dto.RegisterResponseDTO;
+import com.userauth.domain.model.User;
+import com.userauth.domain.ports.EmailServicePort;
+import com.userauth.domain.ports.UserServicePort;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Tag(name = "Authentication", description = "Authentication API")
+public class AuthController {
+
+    private final UserServicePort userServicePort;
+    private final EmailServicePort emailServicePort;
+
+    @PostMapping("/register")
+    public ResponseEntity<RegisterResponseDTO> register(@RequestBody RegisterRequestDTO request) {
+        // 1. Verificar si el usuario ya existe
+        User existingUser = userServicePort.findByEmail(request.getEmail());
+        if (existingUser != null) {
+            RegisterResponseDTO response = new RegisterResponseDTO();
+            response.setMessage("Email already in use");
+            response.setEmail(request.getEmail());
+            return ResponseEntity.badRequest().body(response);
+        }
+
+        // 2. Registrar el usuario
+        User user = userServicePort.registerUser(request.getFullName(), request.getEmail());
+
+        // 3. Generar token de activación
+        String activationToken = UUID.randomUUID().toString();
+
+        // 4. Enviar email de activación
+        emailServicePort.sendActivationEmail(user.getEmail(), activationToken);
+
+        // 5. Preparar respuesta
+        RegisterResponseDTO response = new RegisterResponseDTO();
+        response.setMessage("Registration successful. Please check your email to activate your account.");
+        response.setEmail(user.getEmail());
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=user-auth-api

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,39 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/userauthdb?serverTimezone=UTC
+    username: root
+    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+
+  springdoc:
+    api-docs:
+      path: /v3/api-docs
+    swagger-ui:
+      path: /swagger-ui.html
+
+  mail:
+    host: in-v3.mailjet.com
+    port: 587
+    username: 3199ac38f5e85c9a991f34d243886c9d
+    password: 80e8a276c0c185e53dd9561bf09343dd
+    properties:
+      mail:
+        from: ctruiz0515@gmail.com
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+app:
+  base-url: http://localhost:8080
+
+server:
+  port: 8080

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS users (
+    id BINARY(16) PRIMARY KEY,
+    full_name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255),
+    active BOOLEAN DEFAULT FALSE,
+    activation_token VARCHAR(255),
+    token_expiration TIMESTAMP
+    );


### PR DESCRIPTION
📌 Pull Request: Registro de usuario con flujo de activación por email
🚀 Cambios principales:
Implementado el endpoint /api/auth/register para registrar nuevos usuarios.

Generación de token único de activación por usuario.

Envío de email con enlace de activación utilizando MailJet SMTP.

Validación de email duplicado antes de crear un nuevo usuario.

Manejadores globales para excepciones personalizadas (InvalidTokenException, TokenExpiredException, etc.).

Configuración de Swagger para documentación de la API.

🔄 Ramas involucradas:
Base: feature/auth/register-user

Comparación: feat: add user registration with email flow